### PR TITLE
Sessieinfo voordat een sessie wordt gestart.

### DIFF
--- a/app/Http/Controllers/LocationController.php
+++ b/app/Http/Controllers/LocationController.php
@@ -26,7 +26,7 @@ class LocationController extends Controller
             'latitude' => 'numeric',
             'longitude' => 'numeric',
             'user_id' => 'required|exists:users,id',
-            'tariff_per_kwh' => 'numeric'
+            'tarrif_per_kwh' => 'numeric'
         ]);
 
         $location = Location::create($validated);

--- a/app/Http/Controllers/TarrifController.php
+++ b/app/Http/Controllers/TarrifController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Location;
+
+class TarrifController extends Controller
+{
+    public function getTarrif($location_id)
+    {
+        $location = Location::find($location_id);
+        return response()->json($location->tarrif_per_kwh);
+    }
+}

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -13,6 +13,6 @@ class Location extends Model
         'user_id',
         'name',
         'address',
-        'tariff_per_kwh'
+        'tarrif_per_kwh'
     ];
 }

--- a/database/migrations/2025_05_29_162639_create_locations_table.php
+++ b/database/migrations/2025_05_29_162639_create_locations_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->unsignedBigInteger('user_id');
             $table->string('name');
             $table->string('address');
-            $table->decimal('tariff_per_kwh', 8, 2);
+            $table->decimal('tarrif_per_kwh', 8, 2);
             $table->timestamps();
 
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\AdminController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\LocationController;
 use App\Http\Controllers\CreditController;
+use App\Http\Controllers\TarrifController;
 
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
@@ -23,8 +24,10 @@ Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);
 
 Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);
+Route::post('/tarrif/{location_id}', [TarrifController::class, 'getTarrif']);
 
 Route::middleware('auth:sanctum')->group(function () {
+    
     Route::post('/sockets', [SocketController::class, 'index']);
     Route::post('/socket/new', [SocketController::class, 'store']);
 


### PR DESCRIPTION
Gebruikers kunnen nu zien hoe lang ze kunnen laden.
Als het saldo lager dan het tarief is kan je geen sessie starten, ook was er een typefout, tariff moest tarrif zijn, ik heb dit aangepast in de model en migration, en vervolgens 
```bash
php artisan migrate:fresh
```
gedaan.